### PR TITLE
Fix incorrect argument order

### DIFF
--- a/InjectModuleInitializer.targets
+++ b/InjectModuleInitializer.targets
@@ -9,7 +9,7 @@
       <InjectExtraArgs Condition="'$(AssemblyOriginatorKeyFile)' != ''">/k:"$(AssemblyOriginatorKeyFile)"</InjectExtraArgs>
     </PropertyGroup>
 
-    <Exec Command='"$(InjectModuleInitializerTool)" "$(TargetPath)" $(InjectExtraArgs)' />
+    <Exec Command='"$(InjectModuleInitializerTool)" $(InjectExtraArgs) "$(TargetPath)"' />
 
     <!-- Make sure the incremental build doesn't run this target again -->
     <Touch Files="$(IntermediateOutputPath)$(MSBuildProjectName).moduleinitializer.tmp" AlwaysCreate="true" ForceTouch="true" />


### PR DESCRIPTION
If e.g. signing is enabled, a /keyfile argument is added after the target path in call to InjectModuleInitializerTool. However the target path must always be last or a "error: Invalid argument '{0}', type InjectModuleInitializer /? for help" error is printed.